### PR TITLE
[011-ci] 빌드시 jar 파일 두개 생성되지 않도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor


### PR DESCRIPTION
## What is this PR? 🔎
github-action 도커 빌드 단계에서 중지되는 문제의 원인인듯 하여 빌드시 jar 파일 두개 생성되지 않도록 수정

<에러>
```
ERROR: failed to solve: lstat /tmp/buildkit-mount3429170962/build/libs: no such file or directory
Error: buildx failed with: ERROR: failed to solve: lstat /tmp/buildkit-mount3429170962/build/libs: no such file or directory
```

## Changes ✅
- build.gradle 에 아래와 같은 코드를 추가하여 빌드시 jar 파일 두개 생성되지 않도록 함
```
 jar {
   enabled = false
}
```