### PR TITLE
[011-ci] Dockerfile 경로를 명확하게 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:17-alpine
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+ARG JAR_FILE=/build/libs/wanted-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} /app.jar
 ENTRYPOINT ["java","-Duser.timezone=Asia/Seoul","-jar","/app.jar"]


### PR DESCRIPTION
## What is this PR? 🔎
github-action 도커 빌드 단계에서 중지되는 문제의 원인인듯 하여 Dockerfile 경로를 좀 더 명확하게 수정함

<에러>
```
ERROR: failed to solve: lstat /tmp/buildkit-mount3429170962/build/libs: no such file or directory
Error: buildx failed with: ERROR: failed to solve: lstat /tmp/buildkit-mount3429170962/build/libs: no such file or directory
```

## Changes ✅
- Dockerfile 경로에서 와일드 카드를 제거함